### PR TITLE
Add a leak check script for python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gen/
+python/gen

--- a/python/helpers.py
+++ b/python/helpers.py
@@ -1,0 +1,18 @@
+import glob
+import os
+import pathlib
+import subprocess
+
+DIR = pathlib.Path(__file__).parent.resolve()
+PROTO_PATH = DIR.parent.joinpath('proto')
+GEN_DIR = DIR.joinpath('gen/protobuf')
+
+def compile_protos():
+    GEN_DIR.mkdir(parents=True, exist_ok=True)
+    cmd = ['protoc', '-I', '.', '--python_out', GEN_DIR]
+    cmd.extend(glob.glob("*.proto", root_dir=PROTO_PATH))
+    subprocess.run(cmd, cwd=PROTO_PATH)
+
+def rss_in_kb():
+    res = subprocess.run(['ps', '-p', str(os.getpid()), '-o', 'rss='], capture_output=True, text=True)
+    return int(res.stdout)

--- a/python/leak_simple.py
+++ b/python/leak_simple.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import helpers
+helpers.compile_protos()
+
+from gen.protobuf.simple_pb2 import Recursive
+
+datum = Recursive()
+
+for _ in range(10):
+    for _ in range(1_000_000):
+        Recursive(data=[datum])
+    print("Memory usage {:,} KB".format(helpers.rss_in_kb()))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+protobuf


### PR DESCRIPTION
The simple recursive message leak does not appear in Python as it does in Ruby:

```
pip install -r python/requirements.txt
python python/leak_simple.py
Memory usage 16,480 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
Memory usage 16,512 KB
```

I haven't yet dug into the implementation to confirm but
pip suggests that the binary based on UPB is installed:
```
$ pip uninstall protobuf
Found existing installation: protobuf 5.29.3
Uninstalling protobuf-5.29.3:
  Would remove:
    /Users/rwstauner/.pyenv/versions/3.11.9/lib/python3.11/site-packages/google/_upb/_message.abi3.so
    /Users/rwstauner/.pyenv/versions/3.11.9/lib/python3.11/site-packages/google/protobuf/*
    /Users/rwstauner/.pyenv/versions/3.11.9/lib/python3.11/site-packages/protobuf-5.29.3.dist-info/*
```