### PR TITLE
Add benchmark to compare bigtable versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gen/
+bench/*.hold

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "benchmark-ips"
 gem "google-cloud-bigtable"
 gem "google-protobuf"
 gem "protoboeuf", git: "https://github.com/Shopify/protoboeuf", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.9)
     concurrent-ruby (1.3.5)
     faraday (2.12.2)
@@ -134,9 +135,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  benchmark-ips
   google-cloud-bigtable
   google-protobuf
   protoboeuf!
 
 BUNDLED WITH
-   2.5.22
+   2.6.3

--- a/Rakefile
+++ b/Rakefile
@@ -82,4 +82,28 @@ task bench: :default do
     # Number of reports to run.
     3.times { cmd.call }
   end
+
+  benchmark(:bigtable_version) do |cmd|
+    %w[
+      2.11.0
+      2.11.1
+    ].each do |v|
+      # Ensure the desired version is installed.
+      gem_name = "google-cloud-bigtable"
+      if !system(UNBUNDLER_ENV, "gem", "info", "--silent", "--installed", gem_name, "-v", v)
+        system(UNBUNDLER_ENV, "gem", "install", gem_name, "-v", v)
+      end
+
+      %w[
+        long-lived
+        short-lived
+        deep_copy
+      ].each do |test|
+        cmd.call({
+          "BIGTABLE_VERSION" => v,
+          "BIGTABLE_TEST" => test,
+        }.merge(UNBUNDLER_ENV))
+      end
+    end
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -78,5 +78,8 @@ UNBUNDLER_ENV = {
 
 desc("Run benchmarks")
 task bench: :default do
-  # ...
+  benchmark(:lifecycle) do |cmd|
+    # Number of reports to run.
+    3.times { cmd.call }
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -45,3 +45,38 @@ rule "gen/protoboeuf" => ->(_) { FileList["#{PROTO_PATH}/*.proto"] } do
 end
 
 task default: [:generate, :generate_protoboeuf]
+
+$benchmarks_run = 0
+def benchmark(name)
+  return if ENV["BENCH"] && !ENV["BENCH"].split(",").include?(name.to_s)
+
+  puts "\n\n" if ($benchmarks_run += 1) > 1
+  puts "### #{name} benchmark ###"
+
+  hold = Tempfile.create.tap(&:close).path
+
+  cmd = ->(env = {}) do
+    system({"BENCH_HOLD" => hold}.merge(env), RbConfig.ruby, "bench/#{name}.rb")
+  end
+
+  if block_given?
+    yield(cmd)
+  else
+    cmd.call
+  end
+ensure
+  # benchmark-ips might automatically remove this.
+  File.unlink(hold) if hold && File.exist?(hold)
+end
+
+UNBUNDLER_ENV = {
+  # Discard bundler effects on subprocesses
+  # as this benchmark has its own gemfile.
+  "BUNDLER_SETUP" => nil,
+  "RUBYOPT" => nil,
+}
+
+desc("Run benchmarks")
+task bench: :default do
+  # ...
+end

--- a/bench/bigtable_version.rb
+++ b/bench/bigtable_version.rb
@@ -1,0 +1,79 @@
+# typed: false
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "bundler/inline"
+
+version = ENV["BIGTABLE_VERSION"]
+gemfile do
+  gem "google-cloud-bigtable", "= #{version}"
+end
+
+require "google/cloud/bigtable"
+
+Google::Cloud::Bigtable::VERSION.then do |v|
+  if v.to_s != version
+    fail("BigTable version #{v} != #{version}")
+  end
+
+  puts "# Using BigTable version #{v}"
+end
+
+require_relative "../lib/memsize_helpers"
+
+def run
+  20.times do
+    100_000.times do
+      yield
+    end
+    MemsizeHelpers.check_usage
+  end
+end
+
+test_type = ENV['BIGTABLE_TEST']
+
+def new_row_filter
+  Google::Cloud::Bigtable::V2::RowFilter.new
+end
+
+# Instantiate this outside the loop so that if there is leaked memory
+# attached it will show up in the final report.
+filter = new_row_filter
+
+Benchmark.ips do |x|
+  x.config(iterations: 2)
+
+  x.report("bigtable-#{version} #{sprintf "%12s", test_type}") do
+    run do
+      filters = [
+        # In 2.11.0 these RowFilter methods return a cached frozen instance.
+        # In 2.11.1 they return a new instance each time.
+        Google::Cloud::Bigtable::RowFilter.pass,
+        Google::Cloud::Bigtable::RowFilter.block,
+        Google::Cloud::Bigtable::RowFilter.sink,
+        Google::Cloud::Bigtable::RowFilter.strip_value,
+      ].map(&:to_grpc)
+
+      case test_type
+      when "long-lived"
+        # Include our own long-lived instance.
+        filters << filter
+      when "short-lived"
+        filters << new_row_filter
+      when "deep_copy"
+        filters << filter
+        filters = filters.map { |f| Google::Protobuf.deep_copy(f) }
+      else
+        fail("Unknown BIGTABLE_TEST value '#{test_type}")
+      end
+
+      Google::Cloud::Bigtable::V2::RowFilter::Chain.new(filters:)
+    end
+  end
+
+  x.save! ENV.fetch("BENCH_HOLD", "#{__FILE__}.hold")
+
+  x.compare!(order: :baseline)
+end
+
+MemsizeHelpers.report_usage

--- a/bench/lifecycle.rb
+++ b/bench/lifecycle.rb
@@ -1,0 +1,53 @@
+# typed: false
+# frozen_string_literal: true
+
+require "benchmark/ips"
+
+if ENV["USE_PROTOBOUEF"]
+  puts "Using protoboeuf"
+  require_relative "../gen/protoboeuf/simple"
+else
+  require_relative "../gen/protobuf/simple_pb"
+end
+
+require_relative "../lib/memsize_helpers"
+
+def run
+  10.times do
+    1_000_000.times do
+      yield
+    end
+    MemsizeHelpers.check_usage
+  end
+end
+
+datum = Proto::Leak::Recursive.new
+
+Benchmark.ips do |x|
+  x.config(iterations: 2)
+
+  x.report("long-lived") do
+    run do
+      Proto::Leak::Recursive.new(data: [datum])
+    end
+  end
+
+  x.report("short-lived") do
+    run do
+      short = Proto::Leak::Recursive.new
+      Proto::Leak::Recursive.new(data: [short])
+    end
+  end
+
+  x.report("deep_copy") do
+    run do
+      Proto::Leak::Recursive.new(data: [Google::Protobuf.deep_copy(datum)])
+    end
+  end
+
+  x.hold! ENV.fetch("BENCH_HOLD", "#{__FILE__}.hold")
+
+  x.compare!(order: :baseline)
+end
+
+MemsizeHelpers.report_usage

--- a/leak-bigtable.rb
+++ b/leak-bigtable.rb
@@ -2,27 +2,20 @@
 # frozen_string_literal: true
 
 require "google/cloud/bigtable"
-require "objspace"
 
 require_relative "lib/memsize_helpers"
 
 clone_graph = !!ENV['CLONE_GRAPH']
 
 filter = Google::Cloud::Bigtable::V2::RowFilter.new
-memsize_rss_start = MemsizeHelpers.memsize_rss_in_kb
-memsize_rss_current = memsize_rss_start
+MemsizeHelpers.reset!
 
 20.times do
   10_000.times do
     Google::Cloud::Bigtable::V2::RowFilter::Chain.new(filters: [clone_graph ? Google::Protobuf.deep_copy(filter) : filter])
   end
 
-  GC.start
-  memsize_rss_current = MemsizeHelpers.memsize_rss_in_kb
-
-  if ENV["VERBOSE"]
-    puts "Memory usage: #{memsize_rss_current} KB - ruby space #{(ObjectSpace.memsize_of_all / 1000).round(0)} KB"
-  end
+  MemsizeHelpers.check_usage
 end
 
-puts "Total memory growth: #{memsize_rss_current - memsize_rss_start} KB"
+MemsizeHelpers.report_usage

--- a/leak-simple.rb
+++ b/leak-simple.rb
@@ -1,8 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "objspace"
-
 clone_graph = !!ENV['CLONE_GRAPH']
 
 if ENV["USE_PROTOBOUEF"]
@@ -15,20 +13,14 @@ end
 require_relative "lib/memsize_helpers"
 
 datum = Proto::Leak::Recursive.new
-memsize_rss_start = MemsizeHelpers.memsize_rss_in_kb
-memsize_rss_current = memsize_rss_start
+MemsizeHelpers.reset!
 
 10.times do
   1_000_000.times do
     Proto::Leak::Recursive.new(data: [clone_graph ? Google::Protobuf.deep_copy(datum) : datum])
   end
 
-  GC.start
-  memsize_rss_current = MemsizeHelpers.memsize_rss_in_kb
-
-  if ENV["VERBOSE"]
-    puts "Memory usage: #{memsize_rss_current} KB - ruby space #{(ObjectSpace.memsize_of_all / 1000).round(0)} KB"
-  end
+  MemsizeHelpers.check_usage
 end
 
-puts "Total memory growth: #{memsize_rss_current - memsize_rss_start} KB"
+MemsizeHelpers.report_usage

--- a/lib/memsize_helpers.rb
+++ b/lib/memsize_helpers.rb
@@ -1,6 +1,5 @@
 module MemsizeHelpers
   def self.memsize_rss_in_kb
-    _, size = %x(ps -p "#{$$}" -o pid=,rss=).strip.split.map(&:to_i)
-    size
+    %x(ps -p "#{$$}" -o rss=).strip.to_i
   end
 end

--- a/lib/memsize_helpers.rb
+++ b/lib/memsize_helpers.rb
@@ -1,5 +1,60 @@
+require "objspace"
+
 module MemsizeHelpers
   def self.memsize_rss_in_kb
+    # Get a single field from ps for the pid in question.
     %x(ps -p "#{$$}" -o rss=).strip.to_i
+  end
+
+  def self.reset!
+    @memsize_rss_start = memsize_rss_in_kb
+  end
+  reset!
+
+  # Put commas in number to make it easier to read.
+  def self.format_with_delimiter(number)
+    s = number.to_s
+    # Start at the right side (the period or the end).
+    i = s.index('.') || s.size
+    # Step back toward the beginning and insert a comma between every 3 digits.
+    s.insert(i -= 3, ',') while i > 3
+    s
+  end
+
+  def self.check_usage
+    GC.start
+    # Set this so that the report can see the last value from this position.
+    @memsize_rss_last = MemsizeHelpers.memsize_rss_in_kb
+
+    if verbose?
+      # Put newline first to keep these aligned in the middle of the benchmkark-ips output.
+      printf "\n[Memory usage: %11s KB - ruby space %7s KB]",
+        format_with_delimiter(@memsize_rss_last),
+        format_with_delimiter((ObjectSpace.memsize_of_all / 1000).round(0))
+    end
+  end
+
+  def self.memsize_rss_start
+    @memsize_rss_start
+  end
+
+  def self.memsize_rss_last
+    # Get value from last loop iteration if there was one else request it.
+    @memsize_rss_last ||= MemsizeHelpers.memsize_rss_in_kb
+  end
+
+  # Print usage from last check or current value.
+  def self.report_usage
+    printf "\nTotal memory growth: %12s KB\n",
+      format_with_delimiter(memsize_rss_last - memsize_rss_start)
+
+    # This can be handy to watch from a benchmark but shouldn't be used when looking at the speed results.
+    if verbose? && defined?(Benchmark)
+      puts "\n\nNOTE: Benchmark speed results will be skewed by the ObjectSpace.memsize_of_all call performed in VERBOSE mode and should be discarded.\n\n"
+    end
+  end
+
+  def self.verbose?
+    ENV["VERBOSE"]
   end
 end


### PR DESCRIPTION
Adds a benchmark for bigtable version differences.
Currently it's only the microbenchmarks of RowFilter creation.
Also it's based on prior branches and will need to be rebased.