### PR TITLE
Check leak-simple in php

### DIFF
--- a/php/.gitignore
+++ b/php/.gitignore
@@ -1,0 +1,3 @@
+/gen
+/vendor
+/composer.*

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,4 @@
+# Run leak test with docker
+
+cd php
+./docker.sh ./run.sh php leak-simple.php

--- a/php/build.sh
+++ b/php/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd "${0%/*}"
+gen_dir=$PWD/gen
+mkdir -p "$gen_dir"
+
+(cd ../proto && protoc -I . --php_out "$gen_dir" *.proto)

--- a/php/docker.sh
+++ b/php/docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run --rm \
+  -v "$PWD":/app -w /app \
+  composer "$@"

--- a/php/leak-simple.php
+++ b/php/leak-simple.php
@@ -1,0 +1,49 @@
+<?php
+
+set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__FILE__) . '/gen');
+
+require_once 'vendor/autoload.php';
+
+require_once 'GPBMetadata/Simple.php'; // Update to actual path
+require_once 'Proto/Leak/Recursive.php'; // Update to actual path
+
+function memsize_rss_bytes() {
+  # busybox (docker) doesn't support very many ps args.
+  $rss = shell_exec("ps -o pid,rss | awk -v PID=" . getmypid() . " '$1 == PID { print $2 }'");
+  $int = intval($rss);
+  // Not sure what values are possible in this env.
+  if (preg_match("/^\d+m$/", $rss)) {
+    $int *= 1_000_000;
+  } elseif (preg_match("/^\d+k$/", $rss)) {
+    $int *= 1_000;
+  } else {
+    print("WARNING, unknown unit: " . $rss. "\n");
+    return null;
+  }
+  return $int;
+}
+
+$datum = new Proto\Leak\Recursive(); // Adjust class paths based on actual PHP namespaces
+
+$memsize_rss_start = memsize_rss_bytes();
+$memsize_rss_current = $memsize_rss_start;
+
+$data = [];
+for ($i = 0; $i < 10; $i++) {
+    for ($j = 0; $j < 1000000; $j++) {
+        $obj = new Proto\Leak\Recursive(['data' => [$datum]]);
+    }
+
+    // Trigger garbage collection
+    gc_collect_cycles();
+    $memsize_rss_current = memsize_rss_bytes();
+
+    /* if (!empty(getenv('VERBOSE'))) { */
+        $currentMemSize = memory_get_usage();
+        echo "Memory usage: {$memsize_rss_current} - php space " . $currentMemSize .
+             " diff " . ($memsize_rss_current - $currentMemSize) . PHP_EOL;
+    /* } */
+}
+
+echo "Total memory growth: " . ($memsize_rss_current - $memsize_rss_start) . " KB" . PHP_EOL;
+?>

--- a/php/run.sh
+++ b/php/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+composer require google/protobuf
+
+exec "$@"


### PR DESCRIPTION
PHP has code to do arena fusing but it doesn't appear to retain memory
the way the ruby client does:

    Memory usage: 18000000 - php space 1566072 diff 16433928
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Memory usage: 18000000 - php space 1566104 diff 16433896
    Total memory growth: 0 KB

I had AI help me with the php code, not sure if it's correct,
but if I just append to an array the memory grows the way I'd expect.
It does error if I change the `data` key to something else so it's probably right.